### PR TITLE
Added mechanism to check for the template file via a heirarchy of paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ Here's an example rake task that could be placed in your cookbooks Rake file.
       drud.render
     end
 
+### Support for Private Github Repos
+
+If you set the environment variable `DRUD_OAUTH` to a
+[Github Applicaiton access tokent](https://help.github.com/articles/creating-an-access-token-for-command-line-use)
+that token will be used to authenticate the Octokit client and allow access to private repos.
+
+You need to give the Oauth keys "repo" scope which unfortunately only comes as read/write for almost everything in all the repos owned by you.
+
+Right now the only way to give read-only access to specific repos is to create a [Machine User](https://developer.github.com/guides/managing-deploy-keys/#machine-users) assign that user to a "Read-Only" Team for the private repos you want to give  access to Drud for.
+
+### Path search for Template File
+
+By default Drud uses a template that comes embeded in the Drud Gem (`<Path to Drud Gem>/templates/readme.md.erb`). It will also check for a template file at:
+
+* `<current cookbook path>/templates/default/README.md.erb`
+* `~/.chef/README.md.erb`
+* `<Path to Drud Gem>/templates/readme.md.erb`
+
+It checks in the order shown and the first one it finds, it will use. 
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/drud/fork )

--- a/drud.gemspec
+++ b/drud.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'chef', '~> 11.12.8'
+  spec.add_runtime_dependency 'chef', '>= 11.12.8'
   spec.add_runtime_dependency 'octokit', '~> 3.0'
   spec.add_runtime_dependency 'rake', '~> 10.3.2'
 

--- a/lib/drud/readme.rb
+++ b/lib/drud/readme.rb
@@ -77,15 +77,47 @@ module Drud
       markdown = ReadmeTemplate.new(
         metadata: @metadata, tasks: @tasks, credit: @credit
       )
-      template_path = File.join(
-        File.dirname(File.expand_path(__FILE__)),
-        '../../templates/readme.md.erb'
-      )
       readme = markdown.render(File.read(template_path))
       File.open("#{@cookbook}/README.md", 'w') { |file| file.write(readme) }
     end
 
     private
+
+    # Goes thru a heirarchy of potential template locations to get the template_path
+    def template_path
+      # Memoized
+      return @template_path if @template_path
+
+      paths = []
+      paths << File.join(
+        @cookbook,
+        "templates",
+        "default",
+        "README.md.erb"
+      )
+
+      paths << File.join(
+        File.expand_path("~/.chef"),
+        "README.md.erb"
+      )
+
+      paths << File.join(
+        File.dirname(File.expand_path(__FILE__)),
+        '../../templates/readme.md.erb'
+      )
+      
+      paths.each do |path|
+        if File.exists? path
+          @template_path = path
+          puts "Using Template: #{@template_path}"
+          return path
+        end
+      end
+      
+      # IF we got to here then a template was never found
+      STDERR.puts "ERROR: Can not fine a README.md template in:\n\t#{paths.join("\n\t")}"
+      exit(-1)
+    end
 
     # Reads the cookbooks metadata and instantiates an instance of
     # Chef::Cookbook::Metadata


### PR DESCRIPTION
Will now look in a couple of other places to see if there is a template file instead of just the default one built into drud gem.

Will  check for a template file at:

* `<current cookbook path>/templates/default/README.md.erb`
* `~/.chef/README.md.erb`
* `<Path to Drud Gem>/templates/readme.md.erb`

It checks in the order shown and the first one it finds, it will use. 
