### PR TITLE
Can override where the template comes from

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,22 @@ Here's an example rake task that could be placed in your cookbooks Rake file.
       drud.render
     end
 
+### Support for Private Github Repos
+
 If you set the environment variable `DRUD_OAUTH` to a
 [Github Applicaiton access tokent](https://help.github.com/articles/creating-an-access-token-for-command-line-use)
 that token will be used to authenticate the Octokit client and allow access to private repos.
+
+### Path search for Template File
+
+Drud will now check for a template file at:
+
+* `<current cookbook path>/templates/default/README.md.erb`
+* `~/.chef/README.md.erb`
+* `<Path to Drud Gem>/templates/readme.md.erb`  
+    This last option was the only behavior in earlier versions of Drud
+
+It checks in the order shown and the first one it finds, it will use. 
 
 ## Contributing
 

--- a/lib/drud/readme.rb
+++ b/lib/drud/readme.rb
@@ -88,6 +88,48 @@ module Drud
 
     private
 
+    # Goes thru a heirarchy of potential template locations to get the template_path
+    def template_path
+      # Memoized
+      return @template_path if @template_path
+
+      paths = []
+      # Highest priority
+      # A template in templates/default/README.md.erb of the current cookbook
+      paths << File.join(
+        @cookbook,
+        "templates",
+        "default",
+        "README.md.erb"
+      )
+
+      # If there isn't one in the current cookbook
+      # A Template in ~/.chef/README.md.erb
+      paths << File.join(
+        File.expand_path("~/.chef"),
+        "README.md.erb"
+      )
+
+      # If no other template
+      # Use the one built in to the drud gem
+      paths << File.join(
+        File.dirname(File.expand_path(__FILE__)),
+        '../../templates/readme.md.erb'
+      )
+      
+      paths.each do |path|
+        if File.exists? path
+          @template_path = path
+          puts "Using Template: #{@template_path}"
+          return path
+        end
+      end
+      
+      # IF we got to here then a template was never found
+      STDERR.puts "ERROR: Can not fine a README.md template in:\n\t#{paths.join("\n\t")}"
+      exit(-1)
+    end
+
     # Reads the cookbooks metadata and instantiates an instance of
     # Chef::Cookbook::Metadata
     def load_metadata # :doc:


### PR DESCRIPTION
* Replaces Pull Request #16
* Template can be come from the cookbook's template/default director or from ~/.chef
* Updates Readme as well