### PR TITLE
Handles corrupted commit logs.

### DIFF
--- a/lib/drud/readme.rb
+++ b/lib/drud/readme.rb
@@ -107,7 +107,9 @@ module Drud
     # {commit, author}.
     def parse_commits # :doc:
       @logs.map do |log|
-        @commits[log.split("\n").shift] = /(^A[a-z]+: )(.+)$/.match(log)[2]
+        match = (/(^A[a-z]+: )(.+)$/.match(log)[2] rescue nil)
+        next unless match
+        @commits[log.split("\n").shift] = match
       end
     end
 


### PR DESCRIPTION
For instance if there is an embedded newline or invalid character in the log